### PR TITLE
Added retrieve method to Priority ViewSet

### DIFF
--- a/stresslessapi/views/priority.py
+++ b/stresslessapi/views/priority.py
@@ -44,6 +44,22 @@ class PriorityView(ViewSet):
         except ValidationError as ex:
             return Response({"reason": ex.message}, status=status.HTTP_400_BAD_REQUEST)
 
+    def retrieve(self, request, pk=None):
+        """"Handle GET request for single priority"""
+        try:
+            # `pk` is a parameter to this function, and
+            # Django parses it from the URL route parameter
+            #   http://localhost:8000/priorities/2/edit
+            #
+            # The `2` at the end of the route becomes `pk`
+            priority = Priority.objects.get(pk=pk)
+            serializer = PrioritySerializer(priority, context={'request': request})
+            return Response(serializer.data)
+        except Priority.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+        except Exception as ex:
+            return HttpResponseServerError(ex)
+
 
     def update(self, request, pk=None):
         """Handle PUT rquests sent for a priority"""


### PR DESCRIPTION
## Changes

- added retrieve method to `PriorityView` viewset

## Requests / Responses

**Request**

GET `http://localhost:8000/priorities/2` gets a single priority

**Response**

HTTP/1.1 200 OK

```json
{
    "id": 2,
    "app_user": {
        "id": 1,
        "bio": "Welcome to StressLess. I'm the creator and moderator of this application.",
        "image_url": "",
        "user": 1
    },
    "content": "Instead of scrolling Instagram on lunch, I'd like to get outside and walk.",
    "created_on": "2021-09-10",
    "completed": false
}
```

## Testing

- [ ] git fetch --all and checkout to branch `server-edit-priority `
- [ ] run server
- [ ] on client, click the edit button to edit an existing priority and click save
- [ ] verify your edit was received and updated the database 


## Related Issues

- Fixes ticket #8 on client project