### PR TITLE
added an s to object in destroy method under post.py views

### DIFF
--- a/stresslessapi/views/post.py
+++ b/stresslessapi/views/post.py
@@ -85,7 +85,7 @@ class PostView(ViewSet):
         """Handle DELETE requests for a single post"""
         # grab post to be deleted by pk
         try:
-            post = Post.object.get(pk=pk)
+            post = Post.objects.get(pk=pk)
             post.delete()
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
## Changes

- was missing an `s` on object that was throwing an error
-           try:
            post = Post.object`s`.get(pk=pk)
            post.delete()
            return Response({}, status=status.HTTP_204_NO_CONTENT)

## Testing

- [ ] git fetch --all and checkout to branch `server-post-delete`
- [ ] run server 
- [ ] run DELETE `http://localhost:8000/posts/{postId}` in postman and verify `204 No Content`


## Related Issues

- Fixes ticket #15 on client project