### PR TITLE
Added comment_count to comment.py model

### DIFF
--- a/stresslessapi/models/post.py
+++ b/stresslessapi/models/post.py
@@ -17,3 +17,11 @@ class Post(models.Model):
     @owner.setter
     def owner(self, value):
         self.__owner = value
+
+    @property
+    def comment_count(self):
+        return self.__comment_count
+
+    @comment_count.setter
+    def comment_count(self, value):
+        self.__comment_count = value

--- a/stresslessapi/views/post.py
+++ b/stresslessapi/views/post.py
@@ -7,8 +7,8 @@ from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from django.db.models.fields import BooleanField
 from rest_framework import serializers
-from django.db.models import Case, When
-from stresslessapi.models import Post, AppUser
+from django.db.models import Case, When, Count
+from stresslessapi.models import Post, AppUser, Comment
 
 
 class PostSerializer(serializers.ModelSerializer):
@@ -17,7 +17,7 @@ class PostSerializer(serializers.ModelSerializer):
     class Meta:
         model = Post
         fields = ('id', 'app_user', 'title', 'content',
-            'image_url', 'publication_date', 'owner')
+            'image_url', 'publication_date', 'owner', 'comment_count')
 
 
 class PostView(ViewSet):
@@ -105,7 +105,7 @@ class PostView(ViewSet):
         # posts = Post.objects.all()
 
         # get all priorities from the database that correspond to the current user
-        posts = Post.objects.annotate(owner=Case(
+        posts = Post.objects.annotate(comment_count=Count('comment'), owner=Case(
                                                 When(app_user=app_user, then=True),
                                                 default=False,
                                                 output_field=BooleanField()


### PR DESCRIPTION
## Changes

- added `comment_count` custom property to `comment.py` model
- updated `comment.py` viewset serializer with new value
- added `comment_count` to list method annotate

## Requests / Responses

**Request**

GET `http://localhost:8000/posts` to grab all post data

**Response**

HTTP/1.1 200 OK

```json
{
        "id": 1,
        "app_user": 1,
        "title": "Welcome to StressLess",
        "content": "This is the very first post!",
        "image_url": "",
        "publication_date": "2021-09-10T13:24:27.172000Z",
        "owner": true,
        "comment_count": 2
    }
```

## Testing

- [ ] git fetch --all and checkout to branch `server-comment-count`
- [ ] run the server
- [ ] run GET `http://localhost:8000/posts` and verify `comment_count` property has been added


## Related Issues

- Fixes ticket #16 on client project