### PR TITLE
Added serializer to post.py for user full name

### DIFF
--- a/stresslessapi/views/post.py
+++ b/stresslessapi/views/post.py
@@ -11,8 +11,16 @@ from django.db.models import Case, When, Count
 from stresslessapi.models import Post, AppUser, Comment
 
 
+class PostAppUserSerializer(serializers.ModelSerializer):
+    """JSON serializer for comment owner"""
+
+    class Meta:
+        model = AppUser
+        fields = ('id', 'full_name')
+
 class PostSerializer(serializers.ModelSerializer):
     """JSON serializer for posts"""
+    app_user = PostAppUserSerializer(many=False)
 
     class Meta:
         model = Post


### PR DESCRIPTION
## Changes

- added AppUser serializer to `post.py` ViewSet to bring in user's `full_name` property

## Requests / Responses

**Request**

GET `http://localhost:8000/posts`

**Response**

HTTP/1.1 200 OK

```json
{
      "id": 1,
      "app_user": {
          "id": 1,
          "full_name": "Steve Brownlee"
      },
      "title": "Welcome to StressLess",
      "content": "This is the very first post!",
      "image_url": "",
      "publication_date": "2021-09-10T13:24:27.172000Z",
      "owner": true,
      "comment_count": 2
}
```

## Related Issues

- Fixes a last-minute add on