### PR TITLE
Server motivation ViewSet

### DIFF
--- a/stressless/urls.py
+++ b/stressless/urls.py
@@ -20,7 +20,8 @@ from rest_framework import routers
 from stresslessapi.views import (
     login_user, register_user, Profile,
     PriorityView, ReflectionView, PostView,
-    CommentView, UserView, AppUserView, ResourceView )
+    CommentView, UserView, AppUserView, ResourceView,
+    MotivationView)
 
 
 
@@ -34,6 +35,7 @@ router.register(r'comments', CommentView, 'comment')
 router.register(r'users', UserView, 'user')
 router.register(r'appusers', AppUserView, 'app_user')
 router.register(r'resources', ResourceView, 'resource')
+router.register(r'motivation', MotivationView, 'motivation')
 
 
 urlpatterns = [

--- a/stresslessapi/views/__init__.py
+++ b/stresslessapi/views/__init__.py
@@ -7,4 +7,5 @@ from .comment import CommentView
 from .user import UserView
 from .app_user import AppUserView
 from .resource import ResourceView
+from .motivation import MotivationView
 

--- a/stresslessapi/views/motivation.py
+++ b/stresslessapi/views/motivation.py
@@ -21,7 +21,8 @@ class MotivationView(ViewSet):
         # verify user and who is making request
         app_user = AppUser.objects.get(user=request.auth.user)
 
-        motivations = Motivation.objects.all()
+        motivations = Motivation.objects.all().order_by('-id')[0]
 
-        serializer = MotivationSerializer(motivations, many=True, context={'request': request})
+
+        serializer = MotivationSerializer(motivations, many=False, context={'request': request})
         return Response(serializer.data)

--- a/stresslessapi/views/motivation.py
+++ b/stresslessapi/views/motivation.py
@@ -1,0 +1,27 @@
+"""View module for handling requests about admin motivations"""
+from django.contrib.auth.models import User
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers
+from stresslessapi.models import Motivation, AppUser
+
+
+class MotivationSerializer(serializers.ModelSerializer):
+    """JSON serializer for motivations"""
+    class Meta:
+        model = Motivation
+        fields = '__all__'
+
+
+class MotivationView(ViewSet):
+    """App motivation viewset"""
+
+    def list(self, request):
+        """Handle GET requests to motivation data table"""
+        # verify user and who is making request
+        app_user = AppUser.objects.get(user=request.auth.user)
+
+        motivations = Motivation.objects.all()
+
+        serializer = MotivationSerializer(motivations, many=True, context={'request': request})
+        return Response(serializer.data)

--- a/stresslessapi/views/resource.py
+++ b/stresslessapi/views/resource.py
@@ -1,4 +1,4 @@
-"""View module for handling requests about user profile"""
+"""View module for handling requests about resources"""
 from django.contrib.auth.models import User
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response


### PR DESCRIPTION
## Changes

- added motivation viewset and updated urls.py and __init__
- add `order_by` -id and only grab the first object [0]
- server only returns `last` id from motivation data table which would be the latest to date

## Requests / Responses

**Request**

GET `http://localhost:8000/motivation`

**Response**

HTTP/1.1 200 OK

```json
{
    "id": 2,
    "title": "Life Changes. Do your expectations reflect that?",
    "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Morbi tristique senectus et netus et malesuada fames ac.",
    "created_on": "2021-09-11",
    "app_user": 1
}
```

## Testing

- [ ] git fetch --all and checkout to branch `server-motivation`
- [ ] run server
- [ ] GET `http://localhost:8000/motivation` and verify one object is returned in response


## Related Issues

- Stretch Goal - admin create and broadcast motivation to user dashboards